### PR TITLE
12-containerization-migration-to-net5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 3.1.201
+dotnet: 5.0
 solution: reference-architecture-api.sln
 sudo: required
 services:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
         "request": "launch",
         "preLaunchTask": "build",
         // If you have changed target frameworks, make sure to update the program path.
-        "program": "${workspaceRoot}/src/Infrastructure.WebApi/bin/Debug/netcoreapp3.1/Infrastructure.WebApi.dll",
+        "program": "${workspaceRoot}/src/Infrastructure.WebApi/bin/Debug/net5.0/Infrastructure.WebApi.dll",
         "args": [],
         "cwd": "${workspaceRoot}/src/Infrastructure.WebApi",
         "stopAtEntry": false,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
 
 WORKDIR /app
 ENV DOTNET_USE_POLLING_FILE_WATCHER 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 
 WORKDIR /app
 ENV DOTNET_USE_POLLING_FILE_WATCHER 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . ./
 RUN dotnet publish ./src/Infrastructure.WebApi/Infrastructure.WebApi.csproj --output /out/ --configuration Release
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/aspnet:5.0
 WORKDIR /app
 COPY --from=build /out .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 networks:
     dbnet:
       driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,9 @@ services:
           - MONGO_DATA_DIR=/data/db
           - MONGO_LOG_DIR=/dev/null
         volumes:
-          - /data/docker_db:/data/db
+          - /tmp/data/docker_db:/data/db
         ports:
-            - 27017:27017
+            - 27018:27017
         networks:
             - dbnet
-        command: mongod --smallfiles --logpath=/dev/null # --quiet
+        command: mongod --logpath=/dev/null # --quiet


### PR DESCRIPTION
- smallfiles switch is no longer supported by mongod
- MacOS no longer lets you write to the root data directory
    so the volume was invalid
- Expose port 27018 in order to connect external tools to the db